### PR TITLE
Handle empty values of categoryId in group positioning

### DIFF
--- a/PositionBehavior.php
+++ b/PositionBehavior.php
@@ -253,7 +253,7 @@ class PositionBehavior extends Behavior
         $condition = [];
         if (!empty($this->groupAttributes)) {
             foreach ($this->groupAttributes as $attribute) {
-                $condition[$attribute] = $this->owner->$attribute;
+                $condition[$attribute] = empty($this->owner->$attribute)?null:$this->owner->$attribute;
             }
         }
         return $condition;


### PR DESCRIPTION
This fix the random positioning issue when categoryId is empty or null in group positioning.
